### PR TITLE
Make SemanticVersion Comparable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@
 pubspec.lock
 
 **/packages/
-
+.fsw.yml
+.packages
+.pub
+packages

--- a/lib/semver.dart
+++ b/lib/semver.dart
@@ -7,14 +7,14 @@ library semver;
 import './src/tokenizer.dart' show tokenize;
 
 /// Represents a tag in the semantic version format: http://semver.org/.
-class SemanticVersion {
+class SemanticVersion extends Object with Comparable {
   final int major;
   final int minor;
   final int patch;
   final String pre;
   final String build;
 
-  const SemanticVersion(this.major, this.minor, this.patch, [this.pre,
+  SemanticVersion(this.major, this.minor, this.patch, [this.pre,
       this.build]);
 
   factory SemanticVersion.fromMap(Map tag) {
@@ -90,6 +90,12 @@ class SemanticVersion {
     }
 
     return version;
+  }
+
+  int compareTo(SemanticVersion other) {
+    if (this < other) return -1;
+    else if (this > other) return 1;
+    else return 0;
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,4 +5,5 @@ description: A 'parser' for valid semantic version tags.
 homepage: https://github.com/guillermooo/dart-semver
 dependencies:
   string_scanner: ">=0.1.3 <1.0.0"
-  unittest: ">=0.11.0+2 <0.12.0"
+dev_dependencies:
+  test: '>=0.12.15+1 <0.13.0'

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,4 +1,0 @@
-#! /usr/bin/env bash
-
-dart test_tokenizer.dart
-dart test_semver.dart

--- a/test/semver_test.dart
+++ b/test/semver_test.dart
@@ -1,10 +1,10 @@
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:semver/semver.dart';
 
 void main() {
   test('can instantiate from string', () {
     var sm = new SemanticVersion.fromString('0.1.0');
-    expect(sm.toString(), equals('0.1.0'));
+    expect(sm.toString(), '0.1.0');
   });
 
   test('can instantiate from map', () {
@@ -13,102 +13,133 @@ void main() {
     data['minor'] = 1;
     data['patch'] = 0;
     var sm = new SemanticVersion.fromMap(data);
-    expect(sm.toString(), equals('0.1.0'));
+    expect(sm.toString(), '0.1.0');
   });
 
   test('can instantiate from default constructor', () {
     var sm = new SemanticVersion(0, 1, 0);
-    expect(sm.toString(), equals('0.1.0'));
+    expect(sm.toString(), '0.1.0');
   });
 
   // comparison ops
   test('can detect identical versions', () {
     var sm = new SemanticVersion(0, 1, 0);
     var sm2 = new SemanticVersion(0, 1, 0);
-    expect(sm == sm2, equals(true));
+    expect(sm == sm2, isTrue);
+    expect(sm.compareTo(sm2), 0);
   });
 
   test('can detect identical complex versions (pre-release)', () {
     var sm = new SemanticVersion(0, 1, 0, 'alpha.10');
     var sm2 = new SemanticVersion(0, 1, 0, 'alpha.10');
-    expect(sm == sm2, equals(true));
+    expect(sm == sm2, isTrue);
+    expect(sm.compareTo(sm2), 0);
   });
 
   test('can detect lesser version based on major component', () {
     var sm = new SemanticVersion(0, 0, 0);
     var sm2 = new SemanticVersion(1, 0, 0);
-    expect(sm < sm2, equals(true));
+    expect(sm < sm2, isTrue);
+    expect(sm.compareTo(sm2), -1);
   });
 
   test('can detect lesser version based on minor component', () {
     var sm = new SemanticVersion(0, 0, 0);
     var sm2 = new SemanticVersion(0, 1, 0);
-    expect(sm < sm2, equals(true));
+    expect(sm < sm2, isTrue);
+    expect(sm.compareTo(sm2), -1);
   });
 
   test('can detect lesser version based on patch component', () {
     var sm = new SemanticVersion(0, 0, 0);
     var sm2 = new SemanticVersion(0, 0, 1);
-    expect(sm < sm2, equals(true));
+    expect(sm < sm2, isTrue);
+    expect(sm.compareTo(sm2), -1);
   });
 
   test('pre-release part makes version smaller', () {
     var sm = new SemanticVersion(0, 0, 0);
     var sm2 = new SemanticVersion(0, 0, 0, 'alpha');
-    expect(sm < sm2, equals(false));
+    expect(sm < sm2, isFalse);
+    expect(sm.compareTo(sm2), 1);
   });
 
   test('absence/presence of build component does not affect test', () {
     var sm = new SemanticVersion(0, 0, 0);
     var sm2 = new SemanticVersion(0, 0, 0, null, '20201010');
-    expect(sm == sm2, equals(true));
+    expect(sm == sm2, isTrue);
+    expect(sm.compareTo(sm2), 0);
   });
 
   test('checking for lesser version fails based on major component', () {
     var sm = new SemanticVersion(1, 0, 0);
     var sm2 = new SemanticVersion(0, 0, 0);
-    expect(sm < sm2, equals(false));
+    expect(sm < sm2, isFalse);
+    expect(sm.compareTo(sm2), 1);
   });
 
   test('checking for lesser version fails based on minor component', () {
     var sm = new SemanticVersion(0, 1, 0);
     var sm2 = new SemanticVersion(0, 0, 0);
-    expect(sm < sm2, equals(false));
+    expect(sm < sm2, isFalse);
+    expect(sm.compareTo(sm2), 1);
   });
 
   test('checking for lesser version fails based on patch component', () {
     var sm = new SemanticVersion(0, 1, 0);
     var sm2 = new SemanticVersion(0, 0, 0);
-    expect(sm < sm2, equals(false));
+    expect(sm < sm2, isFalse);
+    expect(sm.compareTo(sm2), 1);
   });
 
   test('can detect lesser version based on pre-release component', () {
     var sm = new SemanticVersion(0, 0, 0, 'alpha');
     var sm2 = new SemanticVersion(0, 0, 0, 'beta');
-    expect(sm < sm2, equals(true));
+    expect(sm < sm2, isTrue);
+    expect(sm.compareTo(sm2), -1);
   });
 
   test('different build components do not affect test', () {
     var sm = new SemanticVersion(0, 0, 0, null, '200');
     var sm2 = new SemanticVersion(0, 0, 0, null, '201');
-    expect(sm == sm2, equals(true));
+    expect(sm == sm2, isTrue);
+    expect(sm.compareTo(sm2), 0);
   });
 
   test('can compare alphabetic pre-release names', () {
     var sm = new SemanticVersion(0, 0, 0, 'alpha');
     var sm2 = new SemanticVersion(0, 0, 0, 'beta');
-    expect(sm < sm2, equals(true));
+    expect(sm < sm2, isTrue);
+    expect(sm.compareTo(sm2), -1);
   });
 
-    test('can compare numeric pre-release names', () {
-      var sm = new SemanticVersion(0, 0, 0, '200');
-      var sm2 = new SemanticVersion(0, 0, 0, '201');
-      expect(sm < sm2, equals(true));
+  test('can compare numeric pre-release names', () {
+    var sm = new SemanticVersion(0, 0, 0, '200');
+    var sm2 = new SemanticVersion(0, 0, 0, '201');
+    expect(sm < sm2, isTrue);
+    expect(sm.compareTo(sm2), -1);
   });
 
-    test('longer pre-release name wins', () {
-      var sm = new SemanticVersion(0, 0, 0, 'alpha');
-      var sm2 = new SemanticVersion(0, 0, 0, 'alpha.1');
-      expect(sm < sm2, equals(true));
+  test('longer pre-release name wins', () {
+    var sm = new SemanticVersion(0, 0, 0, 'alpha');
+    var sm2 = new SemanticVersion(0, 0, 0, 'alpha.1');
+    expect(sm < sm2, isTrue);
+    expect(sm.compareTo(sm2), -1);
+  });
+
+  test('should be sortable', () {
+    var versionList = [
+      new SemanticVersion(0, 1, 0), // 3
+      new SemanticVersion(0, 0, 0), // 0
+      new SemanticVersion(0, 0, 1), // 1
+      new SemanticVersion(0, 1, 0, 'dev') // 2
+    ];
+
+    versionList.sort();
+    
+    expect(versionList[0], new SemanticVersion(0, 0, 0));
+    expect(versionList[1], new SemanticVersion(0, 0, 1));
+    expect(versionList[2], new SemanticVersion(0, 1, 0, 'dev'));
+    expect(versionList[3], new SemanticVersion(0, 1, 0));
   });
 }

--- a/test/tokenizer_test.dart
+++ b/test/tokenizer_test.dart
@@ -1,4 +1,4 @@
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:semver/src/tokenizer.dart';
 
 void main() {
@@ -6,7 +6,7 @@ void main() {
     test('can tokenize', () {
       var tag = '0.1.0';
       var expected = { 'major': 0, 'minor': 1, 'patch': 0 };
-      expect(tokenize(tag), equals(expected));
+      expect(tokenize(tag), expected);
     });
   });
 
@@ -14,25 +14,25 @@ void main() {
     test('can tokenize alphabetic', () {
       var tag = '0.1.0-alpha';
       var expected = {'major': 0, 'minor': 1, 'patch': 0, 'pre': 'alpha'};
-      expect(tokenize(tag), equals(expected));
+      expect(tokenize(tag), expected);
     });
 
     test('can tokenize numeric', () {
       var tag = '0.1.0-100';
       var expected = {'major': 0, 'minor': 1, 'patch': 0, 'pre': '100'};
-      expect(tokenize(tag), equals(expected));
+      expect(tokenize(tag), expected);
     });
 
     test('can tokenize alphanumeric', () {
       var tag = '0.1.0-alpha100';
       var expected = {'major': 0, 'minor': 1, 'patch': 0, 'pre': 'alpha100'};
-      expect(tokenize(tag), equals(expected));
+      expect(tokenize(tag), expected);
     });
 
     test('can tokenize complex', () {
       var tag = '0.1.0-alpha.100';
       var expected = {'major': 0, 'minor': 1, 'patch': 0, 'pre': 'alpha.100'};
-      expect(tokenize(tag), equals(expected));
+      expect(tokenize(tag), expected);
     });
   });
 
@@ -40,25 +40,25 @@ void main() {
     test('can tokenize tagalphabetic', () {
       var tag = '0.1.0+alpha';
       var expected = {'major': 0, 'minor': 1, 'patch': 0, 'build': 'alpha'};
-      expect(tokenize(tag), equals(expected));
+      expect(tokenize(tag), expected);
     });
 
     test('can tokenize numeric', () {
       var tag = '0.1.0+100';
       var expected = {'major': 0, 'minor': 1, 'patch': 0, 'build': '100'};
-      expect(tokenize(tag), equals(expected));
+      expect(tokenize(tag), expected);
     });
 
     test('can tokenize alphanumeric', () {
       var tag = '0.1.0+alpha100';
       var expected = {'major': 0, 'minor': 1, 'patch': 0, 'build': 'alpha100'};
-      expect(tokenize(tag), equals(expected));
+      expect(tokenize(tag), expected);
     });
 
     test('can tokenize complex', () {
       var tag = '0.1.0+alpha.100';
       var expected = {'major': 0, 'minor': 1, 'patch': 0, 'build': 'alpha.100'};
-      expect(tokenize(tag), equals(expected));
+      expect(tokenize(tag), expected);
     });
   });
 }


### PR DESCRIPTION
@guillermooo 

I'm building something that checks at command line the latest version of dart sdk and compares to currently installed. Using your nifty helpful 👍 library inspired me to update it to make SemanticVersion Comparable so that SemanticVersion sorts.
